### PR TITLE
Load 'i_did_mean' for unknown error test

### DIFF
--- a/test/autocorrect/handling_unknown_errors_test.rb
+++ b/test/autocorrect/handling_unknown_errors_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "i_did_mean"
 
 class HandlingUnknownErrorsTest < Minitest::Test
   class ObscureError


### PR DESCRIPTION
Nice blog post! :) 🚀 

When run in isolation, `test_doesnt_explode_on_unknown_errors` was raising `NoMethodError: undefined method `call' for IDidMean:Module` because `i_did_mean` wasn't required. Essentially, if this test was to be run first, it would fail.

EDIT: It still fails on fresh new `git clone shime/i_did_mean`:

> HandlingUnknownErrorsTest#test_doesnt_explode_on_unknown_errors:
Errno::ENOENT: No such file or directory @ rb_sysopen - /Users/viktor/Developer/Ruby/i_did_mean/backtrace

I manually created that file to get the test to append `obscure` inside.